### PR TITLE
Allow to catch signals via `docker kill` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ADD . /bot/
 
 RUN npm install
 
-CMD ["npm", "start"]
+CMD ["node", "./build/server.js"]


### PR DESCRIPTION
Run node directly, without `npm start`. Process will have pid 1, so `docker kill` command will send signals to node.